### PR TITLE
Fixed OpenGL and linking errors

### DIFF
--- a/Input.cpp
+++ b/Input.cpp
@@ -1,6 +1,9 @@
 #include "Input.h"
 
 namespace SouthwestEngine {
+
+	SDL_Joystick* Input::_joystick;
+
 	void Input::Update() {
 		if (SDL_NumJoysticks() > 0) {
 			if (_joystick == nullptr) {

--- a/InternalShaders.cpp
+++ b/InternalShaders.cpp
@@ -102,7 +102,7 @@ Shader* InternalShaders::Diffuse;
 const char* InternalShaders::DiffuseSrc = R"(
 in vec3 fNormal;
 in vec2 fTexCoord;
-in vec3 fVertexColour;
+in vec4 fVertexColour;
 
 out vec4 oFragCol;
 

--- a/Texture.cpp
+++ b/Texture.cpp
@@ -7,7 +7,7 @@ namespace SouthwestEngine {
 		Height = surface->h;
 
 		// create texture object
-		glActiveTexture(0);
+		glActiveTexture(GL_TEXTURE0);
 		glGenTextures(1, &ID);
 		glBindTexture(GL_TEXTURE_2D, ID);
 
@@ -30,7 +30,7 @@ namespace SouthwestEngine {
 
 	void Texture::Bind() {
 		// Bind this texture to opengl texture 0
-		glActiveTexture(0);
+		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, ID);
 	}
 }

--- a/sw.vcxproj
+++ b/sw.vcxproj
@@ -76,12 +76,19 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <TargetName>Southwest</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(Configuration)\</IntDir>
+    <TargetName>Southwest</TargetName>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <IntDir>$(Configuration)\</IntDir>
+    <TargetName>Southwest</TargetName>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -124,6 +131,10 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib>
+      <AdditionalDependencies>SDL2maind.lib;opengl32.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SDL)\x86-windows-dbg</AdditionalLibraryDirectories>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>


### PR DESCRIPTION
In Input.cpp, Input::_joystick caused a linker error since it wasn't initialized. For glActiveTexture(), I think you meant to use GL_TEXTURE0 based on "Bind this texture to opengl texture 0"